### PR TITLE
Enable systemd setting for IPv6 package forwarding

### DIFF
--- a/debian/postinst
+++ b/debian/postinst
@@ -12,7 +12,8 @@ case "$1" in
 
         # create and load system settings
         echo "net.ipv4.ip_forward=1" > /etc/sysctl.d/ip_forward.conf 
-        sysctl -p /etc/sysctl.d/ip_forward.conf
+        echo "net.ipv6.conf.all.forwarding=1" >> /etc/sysctl.d/ip_forward.conf
+	sysctl -p /etc/sysctl.d/ip_forward.conf
 
         # add and load macvlan module
         echo "macvlan" > /etc/modules-load.d/macvlan.conf


### PR DESCRIPTION
If the system has a native IPv6 address by the ISP and a service inside a VM tries to connect via IPv6, the connection fails due to missing forwarding on qemu host. This pr adds the relevant systemd setting.