### PR TITLE
Update omv-backup-vm to keep entries in list file consistent

### DIFF
--- a/usr/sbin/omv-backup-vm
+++ b/usr/sbin/omv-backup-vm
@@ -8,7 +8,7 @@
 # License version 2. This program is licensed "as is" without any
 # warranty of any kind, whether express or implied.
 #
-# version: 0.3.2
+# version: 0.3.3
 #
 
 if [[ $(id -u) -ne 0 ]]; then
@@ -19,6 +19,7 @@ fi
 export LANG=C.UTF-8
 
 # declare/initialize
+declare -i deprecated=0
 declare -i keep=0
 declare -i poweroff=0
 declare -i poweredoff=0
@@ -280,6 +281,29 @@ if [ ${keep} -gt 0 ]; then
     sed -i "\|${delDir},${backupVm},${delDate}|d" ${listFile}
   done
   IFS=$OFS
+fi
+
+# create temporary file and file descriptors 3 & 4 to write to and from said file
+tmpFile=$(mktemp)
+exec 3>"$tmpFile"
+exec 4<"$tmpFile"
+rm "$tmpFile"
+
+# check file list for deprecated entries and print them to file descriptor 3
+while IFS=, read -r listUuid listBackupDir listBackupVm listDate listUsed; do
+  listDir="${listBackupDir}/${listBackupVm}/${listDate}"
+  if [ ! -d "$listDir" ]; then
+    deprecated=${deprecated}+1
+    echo "${listUuid}" >&3
+  fi
+done < ${listFile}
+
+# get deprecated entries from file descriptor 4 and delete them from the list
+if [ ${deprecated} -gt 0 ]; then
+  _log "Removing ${deprecated} deprecated entries from list file '${listFile}'."
+  while read -r delUuid; do
+    sed -i "\|${delUuid}|d" ${listFile}
+  done <&4
 fi
 
 _log "Done."

--- a/usr/sbin/omv-backup-vm
+++ b/usr/sbin/omv-backup-vm
@@ -8,7 +8,7 @@
 # License version 2. This program is licensed "as is" without any
 # warranty of any kind, whether express or implied.
 #
-# version: 0.3.1
+# version: 0.3.2
 #
 
 if [[ $(id -u) -ne 0 ]]; then
@@ -247,6 +247,9 @@ if [ ${poweroff} -eq 1 ] && [ ${poweredoff} -eq 1 ]; then
   _log "Power on ${backupVm}..."
   virsh start ${backupVm}
 fi
+
+# add trailing slash to $backupDir, if there is none, to keep entries in list file consistent
+backupDir=$(echo "$backupDir" | sed "s|[^/]$|&/|")
 
 # add entry to list file
 used=$(du --block-size=1 "${backupVmDir}" | awk '{ print $1 }')


### PR DESCRIPTION
Add trailing slash to `$backupDir`, if there is none, to keep entries in list file consistent.

Add check for deprecated entries and remove deprecated entries from backup list.

This solves #23 