### PR TITLE
Handle changed defaults and fix broken exception

### DIFF
--- a/usr/share/openmediavault/engined/rpc/kvm.inc
+++ b/usr/share/openmediavault/engined/rpc/kvm.inc
@@ -1254,8 +1254,11 @@ class OMVRpcServiceKvm extends \OMV\Rpc\ServiceAbstract
         if ($lxc) {
             $cmdArgs[] = sprintf('--filesystem %s,/', $path);
         } else {
-            if ($params['audio']) {
-                $cmdArgs[] = '--sound default';
+            // Since version 3.1.0 of virt-manager, a sound device is
+            // being added unconditionally. Therefore, we just have to
+            // use --sound in case we want no sound device at all.
+            if (!$params['audio']) {
+                $cmdArgs[] = '--sound none';
             }
 
             if ($params['uefi']) {

--- a/usr/share/openmediavault/engined/rpc/kvm.inc
+++ b/usr/share/openmediavault/engined/rpc/kvm.inc
@@ -1294,6 +1294,7 @@ class OMVRpcServiceKvm extends \OMV\Rpc\ServiceAbstract
             if ($params['spice']) {
                 $cmdArgs[] = '--graphics spice,listen=0.0.0.0';
             }
+            $cmdArgs[] = '--channel unix,target_type=virtio';
         }
 
         $cmdArgs[] = sprintf('--print-xml%s', $printStep);

--- a/usr/share/openmediavault/engined/rpc/kvm.inc
+++ b/usr/share/openmediavault/engined/rpc/kvm.inc
@@ -1294,7 +1294,6 @@ class OMVRpcServiceKvm extends \OMV\Rpc\ServiceAbstract
             if ($params['spice']) {
                 $cmdArgs[] = '--graphics spice,listen=0.0.0.0';
             }
-            $cmdArgs[] = '--channel unix,target_type=virtio';
         }
 
         $cmdArgs[] = sprintf('--print-xml%s', $printStep);

--- a/usr/share/openmediavault/engined/rpc/kvm.inc
+++ b/usr/share/openmediavault/engined/rpc/kvm.inc
@@ -1254,7 +1254,7 @@ class OMVRpcServiceKvm extends \OMV\Rpc\ServiceAbstract
         if ($lxc) {
             $cmdArgs[] = sprintf('--filesystem %s,/', $path);
         } else {
-            // Since version 3.1.0 of virt-manager, a sound device is
+            // Since version 3.1.0 of virt-installer, a sound device is
             // being added unconditionally. Therefore, we just have to
             // use --sound in case we want no sound device at all.
             if (!$params['audio']) {
@@ -1277,7 +1277,7 @@ class OMVRpcServiceKvm extends \OMV\Rpc\ServiceAbstract
                 $printStep = '';
             }
 
-            // Since version 4.0.0 of virt-manager, a TPM is
+            // Since version 4.0.0 of virt-installer, a TPM is
             // being created automatically when using UEFI.
             if($params['uefi'] && !$params['tpm']) {
                 $cmdArgs[] = '--tpm none';

--- a/usr/share/openmediavault/engined/rpc/kvm.inc
+++ b/usr/share/openmediavault/engined/rpc/kvm.inc
@@ -1134,7 +1134,7 @@ class OMVRpcServiceKvm extends \OMV\Rpc\ServiceAbstract
                     break;
             }
             if($archOk !== true) {
-                throw(gettext('Incompatible cpu and architecture!'));
+                throw new \OMV\Exception( gettext('Incompatible cpu and architecture!'));
             }
         }
         $vcpu = $params['vcpu'];

--- a/usr/share/openmediavault/engined/rpc/kvm.inc
+++ b/usr/share/openmediavault/engined/rpc/kvm.inc
@@ -1277,6 +1277,12 @@ class OMVRpcServiceKvm extends \OMV\Rpc\ServiceAbstract
                 $printStep = '';
             }
 
+            // Since version 4.0.0 of virt-manager, a TPM is
+            // being created automatically when using UEFI.
+            if($params['uefi'] && !$params['tpm']) {
+                $cmdArgs[] = '--tpm none';
+            }
+
             if ($params['tpm']) {
                 $cmdArgs[] = '--tpm backend.type=emulator,backend.version=2.0,model=tpm-tis';
             }


### PR DESCRIPTION
I recently found out that there are some changes to the behavior of `virt-installer`. Keep in mind that Debian 12 currently ships with `virt-installer` 4.1.0.

- Since 3.1.0, a [sound device is being added by default](https://github.com/virt-manager/virt-manager/blob/main/NEWS.md?plain=1#L69). This change makes the "Sound" checkbox on creation of a new virtual machine practically useless. This is fixed by inverting the if-condition to set the ``--sound`` option explicitly to none.
- Since 4.0.0, a [TPM device is being added by default when using UEFI](https://github.com/virt-manager/virt-manager/blob/main/NEWS.md?plain=1#L50). This is quite unexpected, as we have a separate option for TPM. This is fixed by a new condition to set ``--tpm`` explicitly to none.

Additionally, I found a little bug. There's an exception being thrown out of `gettext()`. That makes no sense. I fixed that by throwing a new exception with the output of `gettext()` as message.
