### PR TITLE
Remove hard-coded channel for QEMU Guest Agent

### DIFF
--- a/usr/share/openmediavault/engined/rpc/kvm.inc
+++ b/usr/share/openmediavault/engined/rpc/kvm.inc
@@ -1285,7 +1285,6 @@ class OMVRpcServiceKvm extends \OMV\Rpc\ServiceAbstract
             if ($params['spice']) {
                 $cmdArgs[] = '--graphics spice,listen=0.0.0.0';
             }
-            $cmdArgs[] = '--channel unix,target_type=virtio';
         }
 
         $cmdArgs[] = sprintf('--print-xml%s', $printStep);
@@ -1305,11 +1304,6 @@ class OMVRpcServiceKvm extends \OMV\Rpc\ServiceAbstract
             }
         }
 
-        // add guest agent name
-        if (!$lxc) {
-            $this->addNameToUnixChannel($xmlFile);
-        }
-
         // import newly created xml file
         $cmdArgs = [];
         if ($lxc) {
@@ -1323,20 +1317,6 @@ class OMVRpcServiceKvm extends \OMV\Rpc\ServiceAbstract
 
         // remove temporary xml file
         unlink($xmlFile);
-    }
-
-    private function addNameToUnixChannel($path)
-    {
-        $xml = new SimpleXMLElement(file_get_contents($path));
-        $channel = $xml->xpath("//channel[@type='unix']");
-        $guest = 'org.qemu.guest_agent.0'; // The new name for the target
-        if ($channel) {
-            $target = $channel[0]->target;
-            if (!$target->attributes()->name) {
-                $target->addAttribute('name', $guest);
-            }
-        }
-        $xml->asXML($path);
     }
 
     private function addVmBridgeNic($vmname, $mac, $net)


### PR DESCRIPTION
The current code adds the channel for the QEMU Guest Agent to every newly created virtual machine. But that's not necessary, as there are a lot of cases where they are not being available (e.g., when running Windows).

Instead, it's better to rely on `virt-manager`. When the selected guest operating system is able to run the QEMU Guest Agent, it adds the channel automatically to the XML output. Therefore, the code complexity can be decreased by removing the duplicate code (duplicate in terms of it's already being handled by `virt-manager`).

<details>

<summary>Examples</summary>

### First, we create a machine based on `linux2022` - automatically with channel for Guest Agent

Input:

```
virt-install --print-xml --name Test --memory 4096 --os-variant linux2022 --sound none  --boot uefi,loader_secure=no --tpm none --graphics spice,listen=0.0.0.0
```

Output:

```xml
<domain type="kvm">
  <name>Test</name>
  <uuid>ce9381b7-38cc-4f4f-af7a-e8b7d4a09869</uuid>
  <metadata>
    <libosinfo:libosinfo xmlns:libosinfo="http://libosinfo.org/xmlns/libvirt/domain/1.0">
      <libosinfo:os id="http://libosinfo.org/linux/2022"/>
    </libosinfo:libosinfo>
  </metadata>
  <memory>4194304</memory>
  <currentMemory>4194304</currentMemory>
  <vcpu>2</vcpu>
  <os firmware="efi">
    <type arch="x86_64" machine="q35">hvm</type>
    <loader secure="no"/>
    <boot dev="hd"/>
  </os>
  <features>
    <acpi/>
    <apic/>
    <vmport state="off"/>
  </features>
  <cpu mode="host-passthrough"/>
  <clock offset="utc">
    <timer name="rtc" tickpolicy="catchup"/>
    <timer name="pit" tickpolicy="delay"/>
    <timer name="hpet" present="no"/>
  </clock>
  <pm>
    <suspend-to-mem enabled="no"/>
    <suspend-to-disk enabled="no"/>
  </pm>
  <devices>
    <emulator>/usr/bin/qemu-system-x86_64</emulator>
    <disk type="file" device="disk">
      <driver name="qemu" type="qcow2" discard="unmap"/>
      <source file="/var/lib/libvirt/images/Test-3.qcow2"/>
      <target dev="vda" bus="virtio"/>
    </disk>
    <controller type="usb" model="qemu-xhci" ports="15"/>
    <controller type="pci" model="pcie-root"/>
    <controller type="pci" model="pcie-root-port"/>
    <controller type="pci" model="pcie-root-port"/>
    <controller type="pci" model="pcie-root-port"/>
    <controller type="pci" model="pcie-root-port"/>
    <controller type="pci" model="pcie-root-port"/>
    <controller type="pci" model="pcie-root-port"/>
    <controller type="pci" model="pcie-root-port"/>
    <controller type="pci" model="pcie-root-port"/>
    <controller type="pci" model="pcie-root-port"/>
    <controller type="pci" model="pcie-root-port"/>
    <controller type="pci" model="pcie-root-port"/>
    <controller type="pci" model="pcie-root-port"/>
    <controller type="pci" model="pcie-root-port"/>
    <controller type="pci" model="pcie-root-port"/>
    <interface type="network">
      <source network="default"/>
      <mac address="52:54:00:f0:a4:3f"/>
      <model type="virtio"/>
    </interface>
    <console type="pty"/>
    <channel type="unix">
      <source mode="bind"/>
      <target type="virtio" name="org.qemu.guest_agent.0"/>
    </channel>
    <channel type="spicevmc">
      <target type="virtio" name="com.redhat.spice.0"/>
    </channel>
    <input type="tablet" bus="usb"/>
    <graphics type="spice" port="-1" tlsPort="-1" autoport="yes" listen="0.0.0.0">
      <image compression="off"/>
    </graphics>
    <video>
      <model type="virtio"/>
    </video>
    <redirdev bus="usb" type="spicevmc"/>
    <redirdev bus="usb" type="spicevmc"/>
    <memballoon model="virtio"/>
    <rng model="virtio">
      <backend model="random">/dev/urandom</backend>
    </rng>
  </devices>
</domain>
```

### Now create a `win10` machine - automatically without channel for Guest Agent

Input:

```
virt-install --print-xml --name Test --memory 4096 --os-variant win10 --sound none  --boot uefi,loader_secure=no --tpm none --graphics spice,listen=0.0.0.0
```

Output:
```xml
<domain type="kvm">
  <name>Test</name>
  <uuid>14a3075c-1fce-4494-98d1-6e163a7e1130</uuid>
  <metadata>
    <libosinfo:libosinfo xmlns:libosinfo="http://libosinfo.org/xmlns/libvirt/domain/1.0">
      <libosinfo:os id="http://microsoft.com/win/10"/>
    </libosinfo:libosinfo>
  </metadata>
  <memory>4194304</memory>
  <currentMemory>4194304</currentMemory>
  <vcpu>2</vcpu>
  <os firmware="efi">
    <type arch="x86_64" machine="q35">hvm</type>
    <loader secure="no"/>
    <boot dev="hd"/>
  </os>
  <features>
    <acpi/>
    <apic/>
    <hyperv>
      <relaxed state="on"/>
      <vapic state="on"/>
      <spinlocks state="on" retries="8191"/>
    </hyperv>
    <vmport state="off"/>
  </features>
  <cpu mode="host-passthrough"/>
  <clock offset="localtime">
    <timer name="rtc" tickpolicy="catchup"/>
    <timer name="pit" tickpolicy="delay"/>
    <timer name="hpet" present="no"/>
    <timer name="hypervclock" present="yes"/>
  </clock>
  <pm>
    <suspend-to-mem enabled="no"/>
    <suspend-to-disk enabled="no"/>
  </pm>
  <devices>
    <emulator>/usr/bin/qemu-system-x86_64</emulator>
    <disk type="file" device="disk">
      <driver name="qemu" type="qcow2" discard="unmap"/>
      <source file="/var/lib/libvirt/images/Test-4.qcow2"/>
      <target dev="sda" bus="sata"/>
    </disk>
    <controller type="usb" model="qemu-xhci" ports="15"/>
    <controller type="pci" model="pcie-root"/>
    <controller type="pci" model="pcie-root-port"/>
    <controller type="pci" model="pcie-root-port"/>
    <controller type="pci" model="pcie-root-port"/>
    <controller type="pci" model="pcie-root-port"/>
    <controller type="pci" model="pcie-root-port"/>
    <controller type="pci" model="pcie-root-port"/>
    <controller type="pci" model="pcie-root-port"/>
    <controller type="pci" model="pcie-root-port"/>
    <controller type="pci" model="pcie-root-port"/>
    <controller type="pci" model="pcie-root-port"/>
    <controller type="pci" model="pcie-root-port"/>
    <controller type="pci" model="pcie-root-port"/>
    <controller type="pci" model="pcie-root-port"/>
    <controller type="pci" model="pcie-root-port"/>
    <interface type="network">
      <source network="default"/>
      <mac address="52:54:00:85:71:55"/>
      <model type="e1000e"/>
    </interface>
    <console type="pty"/>
    <channel type="spicevmc">
      <target type="virtio" name="com.redhat.spice.0"/>
    </channel>
    <input type="tablet" bus="usb"/>
    <graphics type="spice" port="-1" tlsPort="-1" autoport="yes" listen="0.0.0.0">
      <image compression="off"/>
    </graphics>
    <video>
      <model type="qxl"/>
    </video>
    <redirdev bus="usb" type="spicevmc"/>
    <redirdev bus="usb" type="spicevmc"/>
  </devices>
</domain>
```

### Diff between outputs

```diff
<   <uuid>db380e87-733e-432a-9d05-6dba5cb521af</uuid>
---
>   <uuid>7e44ba8c-f1b4-448e-9691-127f3e584474</uuid>
6c6
<       <libosinfo:os id="http://libosinfo.org/linux/2022"/>
---
>       <libosinfo:os id="http://microsoft.com/win/10"/>
19a20,24
>     <hyperv>
>       <relaxed state="on"/>
>       <vapic state="on"/>
>       <spinlocks state="on" retries="8191"/>
>     </hyperv>
23c28
<   <clock offset="utc">
---
>   <clock offset="localtime">
26a32
>     <timer name="hypervclock" present="yes"/>
36,37c42,43
<       <source file="/var/lib/libvirt/images/Test-6.qcow2"/>
<       <target dev="vda" bus="virtio"/>
---
>       <source file="/var/lib/libvirt/images/Test-5.qcow2"/>
>       <target dev="sda" bus="sata"/>
57,58c63,64
<       <mac address="52:54:00:37:a0:cb"/>
<       <model type="virtio"/>
---
>       <mac address="52:54:00:20:7e:2a"/>
>       <model type="e1000e"/>
61,64d66
<     <channel type="unix">
<       <source mode="bind"/>
<       <target type="virtio" name="org.qemu.guest_agent.0"/>
<     </channel>
73c75
<       <model type="virtio"/>
---
>       <model type="qxl"/>
77,80d78
<     <memballoon model="virtio"/>
<     <rng model="virtio">
<       <backend model="random">/dev/urandom</backend>
<     </rng>
```
</details>
